### PR TITLE
Add Volatility output as an option for an input for MKDecrypt

### DIFF
--- a/MKDecrypt.py
+++ b/MKDecrypt.py
@@ -30,6 +30,8 @@ def main():
 		truecrypt.tc 123...def''')
 	parser.add_argument('-v', '--verbose', action='store_true', help='''
 		verbose output''')
+	parser.add_argument('-X', '--volatility', action='store_true',
+		help='add this switch for passing in volatility dump')
 	rwgroup = parser.add_mutually_exclusive_group()
 	rwgroup.add_argument('-r', '--read-only', action='store_true',
 		help='opens FILE in read only mode (default)')
@@ -42,6 +44,12 @@ def main():
 		hexadecimal string''')
 	args = parser.parse_args()
 	
+
+##  check to see if you are using a raw volatility dump
+	if(args.volatility):
+		masterkeyfile = open(args.MASTERKEY,"rb").read()
+		args.MASTERKEY = binascii.hexlify(masterkeyfile).decode('utf-8')
+
 ##	check to see if this script is being run as root/superuser. exit if not
 	if not os.geteuid() == 0:
 		print("This script needs to be run as root/superuser.")

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ positional arguments:
 optional arguments:
   -h, --help            show this help message and exit
   -v, --verbose         verbose output
+  -X  --volatility      specifies that you are using a volatility file instead of hex chars
   -r, --read-only       opens FILE in read only mode (default)
   -w, --read-write      opens FILE in read/write mode
   -m MOUNTPOINT, --mountpoint MOUNTPOINT


### PR DESCRIPTION
Added a switch to allow you to use a volatility output from truecryptmaster plugin as an option as opposed to hex chars. 

Requested by Nick Furneaux